### PR TITLE
Allow passing client time in unix time seconds

### DIFF
--- a/domestic_test.go
+++ b/domestic_test.go
@@ -121,7 +121,7 @@ func TestFlow(t *testing.T) {
 		}
 
 		// Disclose
-		r7 := Disclose(r3.Value, credJson)
+		r7 := Disclose(r3.Value, credJson, time.Now().Unix())
 		if r7.Error != "" {
 			t.Fatal("Could not disclose credential:", r6.Error)
 		}

--- a/holder_domestic.go
+++ b/holder_domestic.go
@@ -112,8 +112,8 @@ func ReadDomesticCredential(credJson []byte) *Result {
 	return &Result{attributesJson, ""}
 }
 
-func Disclose(holderSkJson, credJson []byte) *Result {
-	return disclose(holderSkJson, credJson, time.Now())
+func Disclose(holderSkJson, credJson []byte, unixTimeSeconds int64) *Result {
+	return disclose(holderSkJson, credJson, time.Unix(unixTimeSeconds, 0))
 }
 
 func disclose(holderSkJson, credJson []byte, now time.Time) *Result {

--- a/testdata/get.sh
+++ b/testdata/get.sh
@@ -1,2 +1,2 @@
-curl -s https://verifier-api.coronacheck.nl/v4/verifier/config | jq -r .payload | base64 -d | jq > config.json
-curl -s https://verifier-api.coronacheck.nl/v4/verifier/public_keys | jq -r .payload | base64 -d | jq > public_keys.json
+curl -s https://verifier-api.coronacheck.nl/v4/verifier/config | jq -r .payload | base64 -d | jq . > config.json
+curl -s https://verifier-api.coronacheck.nl/v4/verifier/public_keys | jq -r .payload | base64 -d | jq . > public_keys.json


### PR DESCRIPTION
This PR allows for clients to pass in the current time in unix time seconds vs having the mobile core layer always passing in `time.Now()` to the idemix module. 

This allows clients to pass in a timestamp that is corrected for clock skew, which can happen on (some) Android devices, as reported in https://github.com/minvws/nl-covid19-coronacheck-app-android/issues/67

A client is still free to provide the equivalent of `time.Now()` too, so functionally this doesn't really change the mobile core module.

This issue was actually filed on the `idemix` module as https://github.com/minvws/nl-covid19-coronacheck-idemix/issues/1 but it turns out that module already uses a supplied timestamp for generating the proof, and the mobile core only needs to expose this, which results in only a minor change.