### PR TITLE
Accept QR code if number of doses is higher than number of doses in dosing schedule

### DIFF
--- a/verifier_european.go
+++ b/verifier_european.go
@@ -208,7 +208,7 @@ func validateVaccination(vacc *hcertcommon.DCCVaccination, rules *europeanVerifi
 
 	nowDate := now.Truncate(24 * time.Hour).UTC()
 	vaccinationValidFrom := dov.Add(time.Duration(validityDelayDays*24) * time.Hour)
-	if nowDate.Before(vaccinationValidFrom) {
+	if nowDate.Before(vaccinationValidFrom) && (vacc.DoseNumber <= vacc.TotalSeriesOfDoses) {
 		return errors.Errorf("Date of vaccination is before the delayed validity date")
 	}
 


### PR DESCRIPTION
As noted in #5, the CoronaCheck Scanner should accept QR codes where the number of doses is higher than the total number of doses in the dosing schedule (i.e., the bearer has received booster doses), even if the booster dose was received less than 14 days ago.

Fixes #5